### PR TITLE
feat(mac-launcher): yaml-defined workflows and dynamic action registry

### DIFF
--- a/mac-launcher/index.js
+++ b/mac-launcher/index.js
@@ -14,6 +14,7 @@ const { startGateway, waitForGateway } = require("./lib/gateway");
 const { startProxy, waitForProxy, warmUpModel } = require("./lib/ollama-proxy");
 const wfDb = require("./lib/workflow-db");
 const { runWorkflow, startRunsSSE } = require("./lib/workflow-runner");
+const wfYaml = require("./lib/workflow-yaml");
 const { trackProcess, trackServer, hookElectronLifecycle } = require("./lib/cleanup");
 const db = require("./lib/db");
 
@@ -522,6 +523,10 @@ async function bootstrap() {
   trackServer(proxyServer);
   try { trackServer(startRunsSSE()); } catch (e) { console.error("[wf] startRunsSSE failed:", e.message); }
   try {
+    const n = wfYaml.syncYamlToDb();
+    console.log(`[wf-yaml] loaded ${n} workflow(s) from ${wfYaml.yamlDir()}`);
+  } catch (e) { console.error("[wf-yaml] sync failed:", e.message); }
+  try {
     const probed = validateMountedFoldersAtBoot();
     const stale = probed.filter((f) => f.stale);
     if (stale.length) console.warn(`[bookmarks] ${stale.length} stale mount(s):`, stale.map((f) => f.path));
@@ -601,16 +606,26 @@ ipcMain.handle("db-update-session-title", (_, sessionId, title) => db.updateSess
 ipcMain.handle("db-delete-session", (_, id) => db.deleteSession(id));
 
 // Workflow IPC
+// Any write that mutates workflow structure also dumps back to YAML so
+// <userData>/workflows/<id>.yaml stays the source of truth.
+const dump = (id) => { try { wfYaml.dumpWorkflow(id); } catch (e) { console.warn("[wf-yaml] dump failed:", e.message); } };
+const stepOwner = (stepId) => {
+  try {
+    const row = wfDb.initDb().prepare(`SELECT workflow_id FROM workflow_steps WHERE id=?`).get(stepId);
+    return row?.workflow_id || null;
+  } catch { return null; }
+};
 ipcMain.handle("wf-list", () => wfDb.listWorkflows());
 ipcMain.handle("wf-get", (_, id) => wfDb.getWorkflow(id));
-ipcMain.handle("wf-create", (_, input) => wfDb.createWorkflow(input || {}));
-ipcMain.handle("wf-update", (_, id, patch) => wfDb.updateWorkflow(id, patch || {}));
-ipcMain.handle("wf-delete", (_, id) => wfDb.deleteWorkflow(id));
-ipcMain.handle("wf-step-add", (_, workflowId, step) => wfDb.addStep(workflowId, step || {}));
-ipcMain.handle("wf-step-update", (_, stepId, patch) => wfDb.updateStep(stepId, patch || {}));
-ipcMain.handle("wf-step-delete", (_, stepId) => wfDb.deleteStep(stepId));
-ipcMain.handle("wf-step-reorder", (_, workflowId, orderedIds) => wfDb.reorderSteps(workflowId, orderedIds || []));
+ipcMain.handle("wf-create", (_, input) => { const wf = wfDb.createWorkflow(input || {}); dump(wf.id); return wf; });
+ipcMain.handle("wf-update", (_, id, patch) => { const wf = wfDb.updateWorkflow(id, patch || {}); if (wf) dump(id); return wf; });
+ipcMain.handle("wf-delete", (_, id) => { const r = wfDb.deleteWorkflow(id); wfYaml.deleteWorkflowYaml(id); return r; });
+ipcMain.handle("wf-step-add", (_, workflowId, step) => { const s = wfDb.addStep(workflowId, step || {}); dump(workflowId); return s; });
+ipcMain.handle("wf-step-update", (_, stepId, patch) => { const s = wfDb.updateStep(stepId, patch || {}); const owner = stepOwner(stepId); if (owner) dump(owner); return s; });
+ipcMain.handle("wf-step-delete", (_, stepId) => { const owner = stepOwner(stepId); const r = wfDb.deleteStep(stepId); if (owner) dump(owner); return r; });
+ipcMain.handle("wf-step-reorder", (_, workflowId, orderedIds) => { const r = wfDb.reorderSteps(workflowId, orderedIds || []); dump(workflowId); return r; });
 ipcMain.handle("wf-run", async (_, workflowId) => runWorkflow(workflowId));
+ipcMain.handle("wf-yaml-reload", () => wfYaml.syncYamlToDb());
 ipcMain.handle("wf-runs-list", (_, workflowId) => wfDb.listRuns(workflowId));
 ipcMain.handle("wf-run-get", (_, runId) => wfDb.getRun(runId));
 

--- a/mac-launcher/lib/workflow-yaml.js
+++ b/mac-launcher/lib/workflow-yaml.js
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// YAML <-> DB sync for workflows. YAML files in <dir>/<id>.yaml are the
+// source of truth; on startup they're upserted into the sqlite workflow_db
+// so the existing runner (which reads from DB) keeps working unchanged.
+// Writes from the UI builder also dump back to YAML so the files stay in
+// sync and can be committed / diffed.
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('yaml');
+const { app } = require('electron');
+
+const wfDb = require('./workflow-db');
+
+function yamlDir() {
+  const dir = path.join(app.getPath('userData'), 'workflows');
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function parseFile(file) {
+  try {
+    const raw = fs.readFileSync(file, 'utf8');
+    const doc = yaml.parse(raw);
+    if (!doc || typeof doc !== 'object') return null;
+    if (!doc.id || !doc.name) return null;
+    return {
+      id: String(doc.id),
+      name: String(doc.name),
+      description: doc.description ?? '',
+      trigger_kind: doc.trigger_kind || 'manual',
+      trigger_config: doc.trigger_config ?? null,
+      steps: Array.isArray(doc.steps) ? doc.steps.map((s, i) => ({
+        id: s.id || `${doc.id}-step-${i}`,
+        ordinal: typeof s.ordinal === 'number' ? s.ordinal : i,
+        kind: s.kind || s.type,
+        config: s.config ?? null,
+      })) : [],
+    };
+  } catch (e) {
+    console.warn(`[wf-yaml] failed to parse ${file}:`, e.message);
+    return null;
+  }
+}
+
+function loadYamlDir(dir = yamlDir()) {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir)
+    .filter((f) => /\.ya?ml$/i.test(f))
+    .map((f) => parseFile(path.join(dir, f)))
+    .filter(Boolean);
+}
+
+function upsertWorkflow(wf) {
+  const db = wfDb.initDb();
+  const existing = db.prepare(`SELECT id FROM workflows WHERE id=?`).get(wf.id);
+  const triggerCfg = wf.trigger_config == null ? null : JSON.stringify(wf.trigger_config);
+  if (existing) {
+    db.prepare(`UPDATE workflows SET name=?, description=?, trigger_kind=?, trigger_config=?, updated_at=CURRENT_TIMESTAMP WHERE id=?`)
+      .run(wf.name, wf.description, wf.trigger_kind, triggerCfg, wf.id);
+  } else {
+    db.prepare(`INSERT INTO workflows (id, name, description, trigger_kind, trigger_config) VALUES (?, ?, ?, ?, ?)`)
+      .run(wf.id, wf.name, wf.description, wf.trigger_kind, triggerCfg);
+  }
+  // Replace steps wholesale — YAML is the source of truth.
+  db.prepare(`DELETE FROM workflow_steps WHERE workflow_id=?`).run(wf.id);
+  const ins = db.prepare(`INSERT INTO workflow_steps (id, workflow_id, ordinal, kind, config) VALUES (?, ?, ?, ?, ?)`);
+  wf.steps.forEach((s, i) => {
+    ins.run(s.id, wf.id, typeof s.ordinal === 'number' ? s.ordinal : i, s.kind,
+      s.config == null ? null : JSON.stringify(s.config));
+  });
+}
+
+function syncYamlToDb(dir = yamlDir()) {
+  const loaded = loadYamlDir(dir);
+  for (const wf of loaded) {
+    try { upsertWorkflow(wf); }
+    catch (e) { console.warn(`[wf-yaml] upsert ${wf.id} failed:`, e.message); }
+  }
+  return loaded.length;
+}
+
+function dumpWorkflow(workflowId, dir = yamlDir()) {
+  const wf = wfDb.getWorkflow(workflowId);
+  if (!wf) return null;
+  const doc = {
+    id: wf.id,
+    name: wf.name,
+    description: wf.description || '',
+    trigger_kind: wf.trigger_kind || 'manual',
+    ...(wf.trigger_config ? { trigger_config: wf.trigger_config } : {}),
+    steps: (wf.steps || []).map((s) => ({
+      id: s.id,
+      ordinal: s.ordinal,
+      kind: s.kind,
+      config: s.config ?? null,
+    })),
+  };
+  const file = path.join(dir, `${wf.id}.yaml`);
+  fs.writeFileSync(file, yaml.stringify(doc), 'utf8');
+  return file;
+}
+
+function deleteWorkflowYaml(workflowId, dir = yamlDir()) {
+  const file = path.join(dir, `${workflowId}.yaml`);
+  try { if (fs.existsSync(file)) fs.unlinkSync(file); } catch {}
+}
+
+module.exports = {
+  yamlDir,
+  loadYamlDir,
+  syncYamlToDb,
+  upsertWorkflow,
+  dumpWorkflow,
+  deleteWorkflowYaml,
+};

--- a/mac-launcher/preload.js
+++ b/mac-launcher/preload.js
@@ -49,6 +49,7 @@ contextBridge.exposeInMainWorld("launcher", {
     run: (workflowId) => ipcRenderer.invoke("wf-run", workflowId),
     runsList: (workflowId) => ipcRenderer.invoke("wf-runs-list", workflowId),
     runGet: (runId) => ipcRenderer.invoke("wf-run-get", runId),
+    reloadYaml: () => ipcRenderer.invoke("wf-yaml-reload"),
   },
 
   // Model selection

--- a/mac-launcher/renderer/app.js
+++ b/mac-launcher/renderer/app.js
@@ -552,6 +552,24 @@ const app = (() => {
     }
   }
 
+  // --- YAML-defined workflows ---
+
+  // Fires the workflow-runner for a button declared as
+  // <button data-action="run-workflow" data-workflow="my-id">. The workflow
+  // itself lives in <userData>/workflows/my-id.yaml and is loaded into the
+  // DB at launch — so the UI no longer needs a dedicated JS handler for
+  // every scripted sequence.
+  async function runWorkflowAction(el) {
+    const id = el.dataset.workflow;
+    if (!id) return appendToast("run-workflow: missing data-workflow attribute");
+    try {
+      const res = await window.launcher.workflows.run(id);
+      appendToast(`Workflow ${id} ${res?.status || "started"}`);
+    } catch (e) {
+      appendToast("Workflow failed: " + e.message);
+    }
+  }
+
   // --- New Workflow (Dashboard) ---
 
   function newWorkflow() {
@@ -805,26 +823,33 @@ const app = (() => {
     // CSP (default-src 'self', no script-src 'unsafe-inline') forbids
     // inline onclick="..." — every interactive element uses data-action
     // instead, dispatched here.
+    // Action registry — replaces the old hardcoded switch. Adding a new
+    // data-action means registering a handler here (or, for scripted
+    // sequences, dropping a YAML file into <userData>/workflows/ and
+    // referencing it via data-action="run-workflow" data-workflow="<id>").
+    const actions = {
+      "single":                   (el) => single(el, "." + el.dataset.group),
+      "toggle":                   (el) => toggle(el),
+      "go":                       (el) => go(Number(el.dataset.step)),
+      "add-invite-row":           ()   => addInviteRow(),
+      "remove-invite-row":        (el) => removeInviteRow(el),
+      "mount-local-folder":       ()   => mountLocalFolder(),
+      "unmount-local-folder":     (el) => unmountLocalFolder(el.dataset.path),
+      "reauthorize-local-folder": (el) => reauthorizeLocalFolder(el.dataset.path),
+      "toggle-connector":         (el) => toggleConnector(el),
+      "app-launch":               ()   => launch(),
+      "open-chat":                (el) => { if (!el.disabled) chat.open(); },
+      "new-workflow":             ()   => newWorkflow(),
+      "navigate":                 (el) => navigateTo(el.dataset.target),
+      "logout":                   ()   => logout(),
+      "reset-onboarding":         ()   => resetOnboarding(),
+      "run-workflow":             (el) => runWorkflowAction(el),
+    };
     document.addEventListener("click", (e) => {
       const el = e.target.closest("[data-action]");
       if (!el) return;
-      switch (el.dataset.action) {
-        case "single":               single(el, "." + el.dataset.group); break;
-        case "toggle":               toggle(el); break;
-        case "go":                   go(Number(el.dataset.step)); break;
-        case "add-invite-row":       addInviteRow(); break;
-        case "remove-invite-row":    removeInviteRow(el); break;
-        case "mount-local-folder":   mountLocalFolder(); break;
-        case "unmount-local-folder": unmountLocalFolder(el.dataset.path); break;
-        case "reauthorize-local-folder": reauthorizeLocalFolder(el.dataset.path); break;
-        case "toggle-connector":     toggleConnector(el); break;
-        case "app-launch":           launch(); break;
-        case "open-chat":            if (!el.disabled) chat.open(); break;
-        case "new-workflow":         newWorkflow(); break;
-        case "navigate":             navigateTo(el.dataset.target); break;
-        case "logout":               logout(); break;
-        case "reset-onboarding":     resetOnboarding(); break;
-      }
+      const fn = actions[el.dataset.action];
+      if (fn) fn(el);
     });
 
     // Init sub-modules

--- a/mac-launcher/scripts/build-dmg.sh
+++ b/mac-launcher/scripts/build-dmg.sh
@@ -94,7 +94,12 @@ codesign --force --sign "$IDENTITY" --entitlements "$ENT_MAIN" "$APP_PATH"
 echo "  Signed: $(basename "$APP_PATH")"
 
 # Verify
-codesign --verify --deep --strict "$APP_PATH" && echo "==> Signature verified OK" || { echo "ERROR: Signature verification failed"; exit 1; }
+if codesign --verify --deep --strict "$APP_PATH"; then
+  echo "==> Signature verified OK"
+else
+  echo "ERROR: Signature verification failed"
+  exit 1
+fi
 
 # Step 2: Stage the DMG layout — the .app and an /Applications symlink so
 # the user can drag-to-install without opening Finder twice.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
 Replaces the renderer's hardcoded switch of click-action handlers with a data-driven action registry, and
  introduces YAML files as the source of truth for workflows. Scripted button sequences can now be added by dropping   a YAML file into <userData>/workflows/ and referencing it via data-action="run-workflow" data-workflow="<id>" —  
  no renderer code changes required.

## Related Issue
<!-- Link to the issue: Fixes #NNN or Closes #NNN. Remove this section if none. -->

## Changes
<!-- Bullet list of key changes. -->

## Type of Change
<!-- Check the one that applies. -->
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
<!-- What testing was done? -->
- [x] `npx prek run --all-files` passes (or equivalently `make check`).
- [ ] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)

## Checklist

### General

- [x] I have read and followed the [contributing guide](https://github.com/NVIDIA/NemoClaw/blob/main/CONTRIBUTING.md).
- [x] I have read and followed the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). (for doc-only changes)

### Code Changes
<!-- Skip if this is a doc-only PR. -->
- [x] Formatters applied — `npx prek run --all-files` auto-fixes formatting (or `make format` for targeted runs).
- [ ] Tests added or updated for new or changed behavior.
- [ ] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for any user-facing behavior changes (new commands, changed defaults, new features, bug fixes that contradict existing docs).

### Doc Changes
<!-- Skip if this PR has no doc changes. -->
- [ ] Follows the [style guide](https://github.com/NVIDIA/NemoClaw/blob/main/docs/CONTRIBUTING.md). Try running the `update-docs` agent skill to draft changes while complying with the style guide. For example, prompt your agent with "`/update-docs` catch up the docs for the new changes I made in this PR."
- [ ] New pages include SPDX license header and frontmatter, if creating a new page.
- [ ] Cross-references and links verified.

---
<!-- DCO sign-off (required by CI). Replace with your real name and email. -->
Signed-off-by: Your Name <your-email@example.com>
