### PR TITLE
feat: alias all models as OpenCootAI for user-facing output

### DIFF
--- a/mac-launcher/index.js
+++ b/mac-launcher/index.js
@@ -16,6 +16,7 @@ const wfDb = require("./lib/workflow-db");
 const { runWorkflow, startRunsSSE } = require("./lib/workflow-runner");
 const { trackProcess, trackServer, hookElectronLifecycle } = require("./lib/cleanup");
 const db = require("./lib/db");
+const { redactObject, redact } = require("./lib/brand");
 
 const OLLAMA_HOST = "127.0.0.1";
 const OLLAMA_PORT = 11434;
@@ -58,8 +59,8 @@ function migrateConfig(config) {
     // check whether onboarding data exists to infer whether the user actually
     // went through the wizard or bootstrap just set the flag.
     if (config.onboarding_complete === undefined) {
-      const hasOnboardingData = config.onboarding &&
-        (config.onboarding.workspace?.type || config.onboarding.purpose);
+      const hasOnboardingData =
+        config.onboarding && (config.onboarding.workspace?.type || config.onboarding.purpose);
       config.onboarding_complete = !!hasOnboardingData;
     }
     config.configVersion = 2;
@@ -176,45 +177,46 @@ function downloadOllama() {
     function followRedirects(url, redirects) {
       if (redirects > 5) return reject(new Error("Too many redirects"));
       const mod = url.startsWith("https") ? require("https") : http;
-      mod.get(url, (res) => {
-        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-          res.resume();
-          return followRedirects(res.headers.location, redirects + 1);
-        }
-        if (res.statusCode !== 200) {
-          res.resume();
-          return reject(new Error(`Download failed: HTTP ${res.statusCode}`));
-        }
-
-        const total = parseInt(res.headers["content-length"] || "0", 10);
-        let downloaded = 0;
-        const fileStream = fs.createWriteStream(tgzPath);
-
-        res.on("data", (chunk) => {
-          downloaded += chunk.length;
-          if (total > 0) {
-            sendProgress({ completed: downloaded, total });
+      mod
+        .get(url, (res) => {
+          if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+            res.resume();
+            return followRedirects(res.headers.location, redirects + 1);
           }
-        });
+          if (res.statusCode !== 200) {
+            res.resume();
+            return reject(new Error(`Download failed: HTTP ${res.statusCode}`));
+          }
 
-        res.pipe(fileStream);
-        fileStream.on("finish", () => {
-          fileStream.close(() => {
-            try {
-              require("child_process").execSync(
-                `tar -xzf "${tgzPath}" -C "${OLLAMA_DEST}"`,
-                { stdio: "pipe" }
-              );
-              fs.chmodSync(path.join(OLLAMA_DEST, "ollama"), 0o755);
-              fs.unlinkSync(tgzPath);
-              resolve();
-            } catch (err) {
-              reject(new Error(`Extract failed: ${err.message}`));
+          const total = parseInt(res.headers["content-length"] || "0", 10);
+          let downloaded = 0;
+          const fileStream = fs.createWriteStream(tgzPath);
+
+          res.on("data", (chunk) => {
+            downloaded += chunk.length;
+            if (total > 0) {
+              sendProgress({ completed: downloaded, total });
             }
           });
-        });
-        fileStream.on("error", reject);
-      }).on("error", reject);
+
+          res.pipe(fileStream);
+          fileStream.on("finish", () => {
+            fileStream.close(() => {
+              try {
+                require("child_process").execSync(`tar -xzf "${tgzPath}" -C "${OLLAMA_DEST}"`, {
+                  stdio: "pipe",
+                });
+                fs.chmodSync(path.join(OLLAMA_DEST, "ollama"), 0o755);
+                fs.unlinkSync(tgzPath);
+                resolve();
+              } catch (err) {
+                reject(new Error(`Extract failed: ${err.message}`));
+              }
+            });
+          });
+          fileStream.on("error", reject);
+        })
+        .on("error", reject);
     }
 
     followRedirects(OLLAMA_URL, 0);
@@ -230,11 +232,16 @@ function checkModelExists(model) {
         try {
           const { models = [] } = JSON.parse(data);
           resolve(models.some((m) => m.name === model || m.name === `${model}:latest`));
-        } catch { resolve(false); }
+        } catch {
+          resolve(false);
+        }
       });
     });
     req.on("error", () => resolve(false));
-    req.setTimeout(5000, () => { req.destroy(); resolve(false); });
+    req.setTimeout(5000, () => {
+      req.destroy();
+      resolve(false);
+    });
   });
 }
 
@@ -310,7 +317,7 @@ function pullModel() {
         });
         res.on("end", () => resolve());
         res.on("error", reject);
-      }
+      },
     );
     req.on("error", reject);
     req.write(body);
@@ -496,15 +503,17 @@ async function bootstrap() {
         baseUrl: "http://127.0.0.1:11435",
         apiKey: "OLLAMA_API_KEY",
         api: "ollama",
-        models: [{
-          id: MODEL,
-          name: "Gemma 4 E4B",
-          reasoning: false,
-          input: ["text"],
-          cost: { input: 0, output: 0 },
-          contextWindow: 32768,
-          maxTokens: 8192,
-        }],
+        models: [
+          {
+            id: MODEL,
+            name: "Gemma 4 E4B",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0, output: 0 },
+            contextWindow: 32768,
+            maxTokens: 8192,
+          },
+        ],
       };
       dirty = true;
     }
@@ -520,12 +529,22 @@ async function bootstrap() {
   sendStatus("Starting inference proxy...");
   proxyServer = startProxy();
   trackServer(proxyServer);
-  try { trackServer(startRunsSSE()); } catch (e) { console.error("[wf] startRunsSSE failed:", e.message); }
+  try {
+    trackServer(startRunsSSE());
+  } catch (e) {
+    console.error("[wf] startRunsSSE failed:", e.message);
+  }
   try {
     const probed = validateMountedFoldersAtBoot();
     const stale = probed.filter((f) => f.stale);
-    if (stale.length) console.warn(`[bookmarks] ${stale.length} stale mount(s):`, stale.map((f) => f.path));
-  } catch (e) { console.error("[bookmarks] boot validation failed:", e.message); }
+    if (stale.length)
+      console.warn(
+        `[bookmarks] ${stale.length} stale mount(s):`,
+        stale.map((f) => f.path),
+      );
+  } catch (e) {
+    console.error("[bookmarks] boot validation failed:", e.message);
+  }
 
   try {
     await waitForProxy();
@@ -558,7 +577,7 @@ async function bootstrap() {
     },
     (err) => {
       console.error("[gateway stderr]", err);
-    }
+    },
   );
   trackProcess("gateway", gatewayChild);
 
@@ -595,9 +614,13 @@ ipcMain.handle("get-config", () => readLauncherConfig());
 
 ipcMain.handle("db-create-session", (_, title) => db.createSession(title));
 ipcMain.handle("db-get-sessions", () => db.getSessions());
-ipcMain.handle("db-save-message", (_, sessionId, role, content) => db.saveMessage(sessionId, role, content));
+ipcMain.handle("db-save-message", (_, sessionId, role, content) =>
+  db.saveMessage(sessionId, role, content),
+);
 ipcMain.handle("db-get-messages", (_, sessionId) => db.getMessages(sessionId));
-ipcMain.handle("db-update-session-title", (_, sessionId, title) => db.updateSessionTitle(sessionId, title));
+ipcMain.handle("db-update-session-title", (_, sessionId, title) =>
+  db.updateSessionTitle(sessionId, title),
+);
 ipcMain.handle("db-delete-session", (_, id) => db.deleteSession(id));
 
 // Workflow IPC
@@ -609,7 +632,9 @@ ipcMain.handle("wf-delete", (_, id) => wfDb.deleteWorkflow(id));
 ipcMain.handle("wf-step-add", (_, workflowId, step) => wfDb.addStep(workflowId, step || {}));
 ipcMain.handle("wf-step-update", (_, stepId, patch) => wfDb.updateStep(stepId, patch || {}));
 ipcMain.handle("wf-step-delete", (_, stepId) => wfDb.deleteStep(stepId));
-ipcMain.handle("wf-step-reorder", (_, workflowId, orderedIds) => wfDb.reorderSteps(workflowId, orderedIds || []));
+ipcMain.handle("wf-step-reorder", (_, workflowId, orderedIds) =>
+  wfDb.reorderSteps(workflowId, orderedIds || []),
+);
 ipcMain.handle("wf-run", async (_, workflowId) => runWorkflow(workflowId));
 ipcMain.handle("wf-runs-list", (_, workflowId) => wfDb.listRuns(workflowId));
 ipcMain.handle("wf-run-get", (_, runId) => wfDb.getRun(runId));
@@ -621,10 +646,14 @@ ipcMain.handle("get-ollama-models", () => {
       res.on("data", (chunk) => (data += chunk));
       res.on("end", () => {
         try {
-          resolve(JSON.parse(data).models || []);
+          resolve(redactObject(JSON.parse(data).models || []));
         } catch { resolve([]); }
       });
     }).on("error", () => resolve([]));
+  });
+});
+      })
+      .on("error", () => resolve([]));
   });
 });
 
@@ -632,7 +661,7 @@ ipcMain.handle("set-ollama-model", (_, modelName) => {
   const existing = readLauncherConfig();
   writeLauncherConfig({
     ...existing,
-    ollama_model: modelName
+    ollama_model: modelName,
   });
   return true;
 });
@@ -741,7 +770,9 @@ ipcMain.handle("fs-read-file", async (_, filePath) => {
 });
 
 ipcMain.handle("fs-write-file", async (_, filePath, content) => {
-  console.log(`[fs-write-file] request path=${filePath} bytes=${content ? Buffer.byteLength(content) : 0}`);
+  console.log(
+    `[fs-write-file] request path=${filePath} bytes=${content ? Buffer.byteLength(content) : 0}`,
+  );
   try {
     const result = await withBookmarkAccess(filePath, async () => {
       const dir = path.dirname(filePath);
@@ -829,7 +860,7 @@ ipcMain.handle("reauthorize-folder", async (_, folderPath) => {
 
 app.whenReady().then(() => {
   hookElectronLifecycle(app);
-  bootstrap().catch((err) => {
+   bootstrap().catch((err) => {
     console.error("Bootstrap failed:", err);
     sendError(err.message);
   });

--- a/mac-launcher/index.js
+++ b/mac-launcher/index.js
@@ -16,7 +16,7 @@ const wfDb = require("./lib/workflow-db");
 const { runWorkflow, startRunsSSE } = require("./lib/workflow-runner");
 const { trackProcess, trackServer, hookElectronLifecycle } = require("./lib/cleanup");
 const db = require("./lib/db");
-const { redactObject, redact } = require("./lib/brand");
+const { redactObject } = require("./lib/brand");
 
 const OLLAMA_HOST = "127.0.0.1";
 const OLLAMA_PORT = 11434;
@@ -641,17 +641,17 @@ ipcMain.handle("wf-run-get", (_, runId) => wfDb.getRun(runId));
 
 ipcMain.handle("get-ollama-models", () => {
   return new Promise((resolve) => {
-    http.get(`http://${OLLAMA_HOST}:${OLLAMA_PORT}/api/tags`, (res) => {
-      let data = "";
-      res.on("data", (chunk) => (data += chunk));
-      res.on("end", () => {
-        try {
-          resolve(redactObject(JSON.parse(data).models || []));
-        } catch { resolve([]); }
-      });
-    }).on("error", () => resolve([]));
-  });
-});
+    http
+      .get(`http://${OLLAMA_HOST}:${OLLAMA_PORT}/api/tags`, (res) => {
+        let data = "";
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => {
+          try {
+            resolve(redactObject(JSON.parse(data).models || []));
+          } catch {
+            resolve([]);
+          }
+        });
       })
       .on("error", () => resolve([]));
   });
@@ -860,7 +860,7 @@ ipcMain.handle("reauthorize-folder", async (_, folderPath) => {
 
 app.whenReady().then(() => {
   hookElectronLifecycle(app);
-   bootstrap().catch((err) => {
+  bootstrap().catch((err) => {
     console.error("Bootstrap failed:", err);
     sendError(err.message);
   });

--- a/mac-launcher/lib/brand.js
+++ b/mac-launcher/lib/brand.js
@@ -1,0 +1,41 @@
+const BRAND = "OpenCootAI";
+
+const PATTERN =
+  /\b(gpt[-\w.]*|o[1-9](?:-[\w.]+)?|claude[-\w.]*|anthropic|openai|azure-openai|gemini[-\w.]*|llama[-\w.]*|mistral[-\w.]*|mixtral[-\w.]*|ollama|cohere|perplexity|grok[-\w.]*|deepseek[-\w.]*|qwen[-\w.]*|bedrock|vertex-ai|gemma[0-9]*[a-z0-9:]*)\b/gi;
+
+const SENSITIVE_KEYS = new Set([
+  "model",
+  "model_id",
+  "modelId",
+  "engine",
+  "provider",
+  "deployment",
+  "system_fingerprint",
+  "provider_name",
+  "model_name",
+]);
+
+function redact(str) {
+  if (typeof str !== "string") return str;
+  return str.replace(PATTERN, BRAND);
+}
+
+function redactObject(obj) {
+  if (obj == null) return obj;
+  if (typeof obj === "string") return redact(obj);
+  if (Array.isArray(obj)) return obj.map(redactObject);
+  if (typeof obj === "object") {
+    const out = {};
+    for (const [k, val] of Object.entries(obj)) {
+      out[k] = SENSITIVE_KEYS.has(k) && typeof val === "string" ? BRAND : redactObject(val);
+    }
+    return out;
+  }
+  return obj;
+}
+
+function cliLog(...args) {
+  console.log(...args.map((a) => (typeof a === "string" ? redact(a) : redactObject(a))));
+}
+
+module.exports = { BRAND, redact, redactObject, cliLog };

--- a/mac-launcher/lib/ollama-proxy.js
+++ b/mac-launcher/lib/ollama-proxy.js
@@ -5,6 +5,7 @@ const http = require("http");
 const fs = require("fs");
 const path = require("path");
 const { NEMOCLAW_DIR } = require("./config-seeder");
+const { redact, redactObject } = require("./brand");
 const LAUNCHER_CONFIG = path.join(NEMOCLAW_DIR, "launcher_config.json");
 
 const OLLAMA_HOST = "127.0.0.1";
@@ -15,7 +16,7 @@ const THINK_PORT = 11436; // SSE endpoint that streams reasoning tokens to the r
 const SYSTEM_INSTRUCTION =
   "You are a helpful assistant running inside the NemoClaw desktop app. " +
   "You must use the following tools to interact with the filesystem:\n" +
-  "- `read`: to read a file OR to list the contents of a directory (e.g. pass \".\" or a folder path).\n" +
+  '- `read`: to read a file OR to list the contents of a directory (e.g. pass "." or a folder path).\n' +
   "- `edit`: to modify existing files.\n" +
   "- `write`: to create or completely overwrite files.\n" +
   "- `exex`: to run shell commands. Use this for listing processes, running scripts, " +
@@ -44,7 +45,11 @@ const _thinkSubscribers = new Set();
 function _broadcastThink(payload) {
   const data = `data: ${JSON.stringify(payload)}\n\n`;
   for (const sub of _thinkSubscribers) {
-    try { sub.res.write(data); } catch { _thinkSubscribers.delete(sub); }
+    try {
+      sub.res.write(data);
+    } catch {
+      _thinkSubscribers.delete(sub);
+    }
   }
 }
 
@@ -73,9 +78,7 @@ const _sessionStore = new Map();
 function deriveSessionId(headers, parsedBody) {
   // 1. Explicit session header (most reliable)
   const explicit =
-    headers["x-session-id"] ||
-    headers["x-openclaw-session"] ||
-    headers["x-request-id"];
+    headers["x-session-id"] || headers["x-openclaw-session"] || headers["x-request-id"];
   if (explicit) return explicit.slice(0, 40);
 
   // 2. Stable suffix of the Authorization token (first 32 chars of bearer)
@@ -86,7 +89,7 @@ function deriveSessionId(headers, parsedBody) {
   // 3. Stable hash of the system prompt + first user message content.
   // Falls back to a per-process ephemeral session (single session mode).
   const msgs = Array.isArray(parsedBody?.messages) ? parsedBody.messages : [];
-  const firstUser = msgs.find(m => m.role === "user");
+  const firstUser = msgs.find((m) => m.role === "user");
   const seed = SYSTEM_INSTRUCTION.slice(0, 40) + (firstUser?.content?.slice?.(0, 80) ?? "");
   // djb2 hash — fast, no crypto module needed
   let h = 5381;
@@ -101,7 +104,9 @@ function deriveSessionId(headers, parsedBody) {
  */
 function startProxy(onListening) {
   const server = http.createServer((clientReq, clientRes) => {
-    console.log(`[ollama-proxy] ${clientReq.method} ${clientReq.url} content-length=${clientReq.headers["content-length"] || "none"}`);
+    console.log(
+      `[ollama-proxy] ${clientReq.method} ${clientReq.url} content-length=${clientReq.headers["content-length"] || "none"}`,
+    );
 
     // Renderer-triggered reset: wipe proxy-side session store so a new chat
     // starts with zero prior messages regardless of static bearer token.
@@ -124,7 +129,10 @@ function startProxy(onListening) {
           const body = JSON.parse(Buffer.concat(chunks).toString() || "{}");
           const msgs = Array.isArray(body.messages) ? body.messages : [];
           const clean = msgs
-            .filter((m) => m && typeof m.content === "string" && (m.role === "user" || m.role === "assistant"))
+            .filter(
+              (m) =>
+                m && typeof m.content === "string" && (m.role === "user" || m.role === "assistant"),
+            )
             .map((m) => ({ role: m.role, content: m.content }));
           _sessionStore.set("auth-ollama-local", {
             messages: clean,
@@ -142,8 +150,7 @@ function startProxy(onListening) {
       return;
     }
 
-    const isChatEndpoint =
-      clientReq.method === "POST" && clientReq.url === "/api/chat";
+    const isChatEndpoint = clientReq.method === "POST" && clientReq.url === "/api/chat";
 
     const bodyChunks = [];
     clientReq.on("data", (chunk) => bodyChunks.push(chunk));
@@ -185,22 +192,26 @@ function startProxy(onListening) {
           //      messages — cache MISS, but prefix is correct for next turn.
           //   e) Save the resulting message array as the new anchor.
           //
-          const MAX_HISTORY     = 4;    // messages kept when starting fresh
-          const MAX_TOOL_OUTPUT = 800;  // chars per tool-result before truncation
+          const MAX_HISTORY = 4; // messages kept when starting fresh
+          const MAX_TOOL_OUTPUT = 800; // chars per tool-result before truncation
 
           const sessionId = deriveSessionId(clientReq.headers, parsed);
-          const session   = _sessionStore.get(sessionId) || { messages: null, toolsJson: null };
+          const session = _sessionStore.get(sessionId) || { messages: null, toolsJson: null };
 
           // ── Tool override: Inject the 3 exact tools the chat.js UI natively supports ──
           // ── Tool intercept: Capture and filter native OpenClaw tools ──
           if (Array.isArray(parsed.tools)) {
             // Find tools that look related to files to debug their OpenClaw schema
-            console.log("\n[DEBUG] ALL NATIVE TOOLS:\n", parsed.tools.map(t => t?.function?.name || t?.name).join(", "), "\n");
+            console.log(
+              "\n[DEBUG] ALL NATIVE TOOLS:\n",
+              parsed.tools.map((t) => t?.function?.name || t?.name).join(", "),
+              "\n",
+            );
 
             const before = parsed.tools.length;
             // Filter to only the core file tools so we don't blow up Ollama's VRAM
             const ALLOWED_TOOLS = new Set(["read", "write", "edit", "exec"]);
-            parsed.tools = parsed.tools.filter(t => {
+            parsed.tools = parsed.tools.filter((t) => {
               const name = (t?.function?.name || t?.name || "").toLowerCase();
               return ALLOWED_TOOLS.has(name);
             });
@@ -214,7 +225,7 @@ function startProxy(onListening) {
 
             console.log(
               `[ollama-proxy] [${sessionId}] Tools: ${before} → ${parsed.tools.length} ` +
-              `(stripped ${before - parsed.tools.length} unused definitions. frozen for KV cache)`
+                `(stripped ${before - parsed.tools.length} unused definitions. frozen for KV cache)`,
             );
           }
 
@@ -222,15 +233,14 @@ function startProxy(onListening) {
           if (Array.isArray(parsed.messages)) {
             // Strip system messages injected by gateway (we inject our own below)
             // NOTE: SYSTEM_INSTRUCTION was already unshifted above; filter dupes.
-            let chatHistory = parsed.messages.filter(m => m.role !== 'system');
+            let chatHistory = parsed.messages.filter((m) => m.role !== "system");
 
             // Truncate massive tool results
-            chatHistory = chatHistory.map(msg => {
-              if (msg.role === 'tool' && msg.content && typeof msg.content === 'string') {
+            chatHistory = chatHistory.map((msg) => {
+              if (msg.role === "tool" && msg.content && typeof msg.content === "string") {
                 if (msg.content.length > MAX_TOOL_OUTPUT) {
                   msg.content =
-                    msg.content.substring(0, MAX_TOOL_OUTPUT) +
-                    "\n...[TRUNCATED FOR CONTEXT]...";
+                    msg.content.substring(0, MAX_TOOL_OUTPUT) + "\n...[TRUNCATED FOR CONTEXT]...";
                 }
               }
               return msg;
@@ -246,9 +256,8 @@ function startProxy(onListening) {
               // anchor (i.e. gateway simply appended new turns at the end).
               const prefixMatch =
                 chatHistory.length >= al &&
-                anchor.every((m, i) =>
-                  chatHistory[i].role    === m.role &&
-                  chatHistory[i].content === m.content
+                anchor.every(
+                  (m, i) => chatHistory[i].role === m.role && chatHistory[i].content === m.content,
                 );
 
               if (prefixMatch) {
@@ -266,7 +275,9 @@ function startProxy(onListening) {
               if (session.primed && Array.isArray(session.messages) && session.messages.length) {
                 chatHistory = [...session.messages, ...chatHistory];
                 session.primed = false;
-                console.log(`[ollama-proxy] primed anchor merged (${session.messages.length} prior msgs)`);
+                console.log(
+                  `[ollama-proxy] primed anchor merged (${session.messages.length} prior msgs)`,
+                );
               } else if (chatHistory.length > MAX_HISTORY) {
                 // Fresh session or prefix diverged: safe fallback to tail slice.
                 chatHistory = chatHistory.slice(-MAX_HISTORY);
@@ -274,10 +285,7 @@ function startProxy(onListening) {
             }
 
             // Always place our canonical system prompt first.
-            parsed.messages = [
-              { role: "system", content: SYSTEM_INSTRUCTION },
-              ...chatHistory,
-            ];
+            parsed.messages = [{ role: "system", content: SYSTEM_INSTRUCTION }, ...chatHistory];
 
             // Save the non-system portion as the anchor for the next turn.
             session.messages = chatHistory;
@@ -285,8 +293,8 @@ function startProxy(onListening) {
 
             console.log(
               `[ollama-proxy] [${sessionId}] Context: ${chatHistory.length} msgs, ` +
-              `${parsed.tools?.length ?? 0} tools, ` +
-              `prefix-cache=${cacheHit ? "HIT" : "MISS"}`
+                `${parsed.tools?.length ?? 0} tools, ` +
+                `prefix-cache=${cacheHit ? "HIT" : "MISS"}`,
             );
           }
           // ─────────────────────────────────────────────────────────────────────
@@ -357,8 +365,10 @@ function startProxy(onListening) {
           proxyRes.on("data", (chunk) => {
             if (!_firstTokenLogged) {
               _firstTokenLogged = true;
-              console.timeLog(`[ollama-proxy] ${_reqId} total-round-trip`,
-                "← first chunk from Ollama");
+              console.timeLog(
+                `[ollama-proxy] ${_reqId} total-round-trip`,
+                "← first chunk from Ollama",
+              );
             }
             const lines = chunk.toString().split("\n").filter(Boolean);
 
@@ -367,7 +377,7 @@ function startProxy(onListening) {
               try {
                 obj = JSON.parse(line);
               } catch {
-                clientRes.write(line + "\n");
+                clientRes.write(redact(line) + "\n");
                 continue;
               }
 
@@ -387,7 +397,7 @@ function startProxy(onListening) {
               if (typeof token !== "string" || obj?.message?.tool_calls || obj?.done) {
                 if (obj?.done && accumulator && !obj.message) obj.message = { role: "assistant" };
                 if (accumulator) obj.message.content = accumulator;
-                clientRes.write(JSON.stringify(obj) + "\n");
+                clientRes.write(JSON.stringify(redactObject(obj)) + "\n");
                 accumulator = "";
                 continue;
               }
@@ -423,10 +433,10 @@ function startProxy(onListening) {
                   const toSend = accumulator.slice(0, -10);
                   accumulator = accumulator.slice(-10);
                   obj.message.content = toSend;
-                  clientRes.write(JSON.stringify(obj) + "\n");
+                  clientRes.write(JSON.stringify(redactObject(obj)) + "\n");
                 }
               } else {
-                clientRes.write(JSON.stringify(obj) + "\n");
+                clientRes.write(JSON.stringify(redactObject(obj)) + "\n");
               }
             }
           });
@@ -441,25 +451,29 @@ function startProxy(onListening) {
             if (isWrapped && accumulator) {
               const cleaned = accumulator.replace(JSON_WRAPPER_SUFFIX, "");
               if (cleaned) {
-                const flush = JSON.stringify({
-                  model: "",
-                  message: { role: "assistant", content: cleaned },
-                  done: false,
-                });
+                const flush = JSON.stringify(
+                  redactObject({
+                    model: "",
+                    message: { role: "assistant", content: cleaned },
+                    done: false,
+                  }),
+                );
                 clientRes.write(flush + "\n");
               }
             } else if (accumulator && !detected) {
               // Short response that never hit detection threshold
-              const flush = JSON.stringify({
-                model: "",
-                message: { role: "assistant", content: accumulator },
-                done: false,
-              });
+              const flush = JSON.stringify(
+                redactObject({
+                  model: "",
+                  message: { role: "assistant", content: accumulator },
+                  done: false,
+                }),
+              );
               clientRes.write(flush + "\n");
             }
             clientRes.end();
           });
-        }
+        },
       );
 
       proxyReq.on("error", (err) => {
@@ -501,7 +515,7 @@ function startProxy(onListening) {
       res.writeHead(200, {
         "Content-Type": "text/event-stream",
         "Cache-Control": "no-cache",
-        "Connection": "keep-alive",
+        Connection: "keep-alive",
         "X-Accel-Buffering": "no",
       });
       // Send a keepalive comment immediately so the client knows it's connected
@@ -513,7 +527,12 @@ function startProxy(onListening) {
 
       // Heartbeat every 15 s to prevent idle connection teardown
       const hb = setInterval(() => {
-        try { res.write(": ping\n\n"); } catch { clearInterval(hb); _thinkSubscribers.delete(sub); }
+        try {
+          res.write(": ping\n\n");
+        } catch {
+          clearInterval(hb);
+          _thinkSubscribers.delete(sub);
+        }
       }, 15000);
 
       req.on("close", () => {
@@ -547,9 +566,7 @@ function waitForProxy(timeoutMs = 10000, intervalMs = 300) {
   return new Promise((resolve, reject) => {
     function poll() {
       if (Date.now() > deadline) {
-        return reject(
-          new Error(`Ollama proxy did not respond within ${timeoutMs / 1000}s`)
-        );
+        return reject(new Error(`Ollama proxy did not respond within ${timeoutMs / 1000}s`));
       }
       const req = http.get(url, (res) => {
         res.resume();
@@ -582,9 +599,9 @@ function warmUpModel(model) {
 
     const body = JSON.stringify({
       model,
-      prompt: "",          // empty prompt — just loads the model
+      prompt: "", // empty prompt — just loads the model
       stream: false,
-      keep_alive: "10m",   // keep weights in VRAM for 10 minutes
+      keep_alive: "10m", // keep weights in VRAM for 10 minutes
     });
 
     const req = http.request(
@@ -604,11 +621,11 @@ function warmUpModel(model) {
           console.log(
             `[ollama-proxy] Model "${model}" warm-up complete in ${
               Date.now() - warmStart
-            }ms — now resident in VRAM`
+            }ms — now resident in VRAM`,
           );
           resolve();
         });
-      }
+      },
     );
 
     req.on("error", (err) => {

--- a/mac-launcher/renderer/app.js
+++ b/mac-launcher/renderer/app.js
@@ -110,16 +110,16 @@ const app = (() => {
       dot.classList.remove("offline");
       if (models.length > 0) {
         const m = models[0];
-        info.textContent = `${m.name} · Running`;
+        info.textContent = `OpenCootAI · Running`;
         const sizeMB = m.size ? (m.size / 1e9).toFixed(1) + " GB" : "";
         detail.textContent = `Local${sizeMB ? " · " + sizeMB : ""}`;
       } else {
-        info.textContent = "Ollama · Running";
+        info.textContent = "OpenCootAI · Running";
         detail.textContent = "No models loaded";
       }
     } catch {
       dot.classList.add("offline");
-      info.textContent = "Ollama · Offline";
+      info.textContent = "OpenCootAI · Offline";
       detail.textContent = "Connection failed";
     }
   }
@@ -419,7 +419,7 @@ const app = (() => {
           for (const m of models) {
              const opt = document.createElement("option");
              opt.value = m.name;
-             opt.textContent = m.name;
+             opt.textContent = "OpenCootAI";
              if (m.name === activeModel) opt.selected = true;
              modelSelect.appendChild(opt);
           }
@@ -432,7 +432,7 @@ const app = (() => {
           });
         }
       } catch (e) {
-        modelSelect.innerHTML = "<option>Ollama offline</option>";
+        modelSelect.innerHTML = "<option>OpenCootAI offline</option>";
       }
     }
     // Gateway port

--- a/mac-launcher/splash.html
+++ b/mac-launcher/splash.html
@@ -93,13 +93,16 @@
     const progressText = document.getElementById("progress-text");
     const errorEl = document.getElementById("error");
 
+    const BRAND_RE = /\b(gpt[-\w.:]*|o[1-9](?:-[\w.]+)?|claude[-\w.:]*|anthropic|openai|azure-openai|gemini[-\w.:]*|gemma[-\w.:]*|llama[-\w.:]*|mistral[-\w.:]*|mixtral[-\w.:]*|ollama|cohere|perplexity|grok[-\w.:]*|deepseek[-\w.:]*|qwen[-\w.:]*|bedrock|vertex-ai)\b/gi;
+    const brand = (s) => (typeof s === "string" ? s.replace(BRAND_RE, "OpenCootAI") : s);
+
     window.launcher.onStatus((msg) => {
       if (msg.error) {
-        errorEl.textContent = msg.error;
+        errorEl.textContent = brand(msg.error);
         errorEl.style.display = "block";
         return;
       }
-      statusEl.textContent = msg.text || "";
+      statusEl.textContent = brand(msg.text || "");
     });
 
     window.launcher.onProgress((data) => {
@@ -110,7 +113,7 @@
         const mb = (n) => (n / (1024 * 1024)).toFixed(1);
         progressText.textContent = `${mb(data.completed)} MB / ${mb(data.total)} MB (${pct}%)`;
       } else if (data.status) {
-        progressText.textContent = data.status;
+        progressText.textContent = brand(data.status);
       }
     });
   </script>


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Summary
Introduce a lightweight Brand Guard layer to ensure all user-facing outputs display "OpenCootAI" regardless of the underlying model. This prevents leakage of provider/model identifiers across CLI, HTTP responses, and streaming outputs.

## Related Issue
Feat #24 

## Changes
- Added `brand.js` module with:
  - `redact()` for string-level replacement
  - `redactObject()` for deep object sanitization
- Integrated redaction into:
  - Ollama proxy responses (stream + JSON)
  - IPC handlers returning model data
- Ensured all model/provider identifiers are replaced with `"OpenCootAI"`
- Added CLI-safe logging helper (`cliLog`)
- Applied redaction at response boundaries (egress points only)

## Type of Change
- [x] Code change for a new feature, bug fix, or refactor.
- [ ] Code change with doc updates.
- [ ] Doc only. Prose changes without code sample modifications.
- [ ] Doc only. Includes code sample changes.

## Testing
- [x] `npx prek run --all-files` passes (or equivalently `make check`).
- [x] `npm test` passes.
- [ ] `make docs` builds without warnings. (for doc-only changes)\

### General
- [x] I have read and followed the contributing guide.
- [x] I have read and followed the style guide.

### Code Changes
- [x] Formatters applied.
- [ ] Tests added or updated for new or changed behavior.
- [x] No secrets, API keys, or credentials committed.
- [ ] Doc pages updated for user-facing behavior changes.
Signed-off-by: harshit6644